### PR TITLE
fix "no server running" with newer tmux versions

### DIFF
--- a/tmc
+++ b/tmc
@@ -293,5 +293,5 @@ fi
 TMPFILE="$(mktemp /tmp/tmux-cluster-XXXXXXXXXXXX)"
 
 echo "$TMUX_CMDS" > "$TMPFILE"
-tmux source-file "$TMPFILE"
+tmux start-server \; source-file "$TMPFILE"
 rm "$TMPFILE"


### PR DESCRIPTION
With tmux 2.2 I always get `no server running on /run/tmux/1000/default` when running tmc.
See also: http://superuser.com/questions/719633/tmux-1-8-gives-failed-to-connect-to-server-when-trying-to-source-a-file

This PR fixes that by starting a tmux server before sourcing the generated commands.
