### PR TITLE
Support for ~/.clusterssh/tags

### DIFF
--- a/tmc
+++ b/tmc
@@ -45,6 +45,9 @@ Options:
                         The hosts in EXCLUDES will not be connected to.
     -w              Create cluster panes in a new window in the current session.
                         Only valid if used in an attached tmux session.
+    -l LAYOUT       Select a tmux layout.
+    -H              Use even-horizontal tmux layout.
+    -V              Use even-vertical tmux layout.
 EOF
 }
 
@@ -88,9 +91,10 @@ DUMP_TMUX_CMDS=""
 CUSTOM_CLUSTER_LINE=""
 EXCLUDED_HOSTS=""
 USE_EXISTING_SESSION=""
+LAYOUT="tiled"
 
 # parse args
-while getopts :hdtc:x:w OPT; do
+while getopts :hdtc:x:wHVl: OPT; do
     case $OPT in
         h)
             usage
@@ -110,6 +114,15 @@ while getopts :hdtc:x:w OPT; do
             ;;
         w)
             USE_EXISTING_SESSION="true"
+            ;;
+        H)
+            LAYOUT="even-horizontal"
+            ;;
+        V)
+            LAYOUT="even-vertical"
+            ;;
+        l)
+            LAYOUT="$OPTARG"
             ;;
         \?)
             echo "error: invalid option -$OPTARG" 1>&2
@@ -277,7 +290,7 @@ fi
 for HOST in $HOSTS; do
     SHELL_CMD="ssh $HOST; [ \$? -eq 255 ] && (echo Press ENTER to close pane; read enter)"
     TMUX_CMDS="${TMUX_CMDS}splitw $TMUX_SESSION_T_ARG \"$SHELL_CMD\"$NL"
-    TMUX_CMDS="${TMUX_CMDS}select-layout $TMUX_SESSION_T_ARG tiled$NL"
+    TMUX_CMDS="${TMUX_CMDS}select-layout $TMUX_SESSION_T_ARG $LAYOUT$NL"
 done
 
 TMUX_CMDS="${TMUX_CMDS}set-window-option $TMUX_SESSION_T_ARG synchronize-panes on$NL"
@@ -294,7 +307,7 @@ else
 fi
 
 # fix issue with incorrect layout after call to switch-client
-TMUX_CMDS="${TMUX_CMDS}select-layout $TMUX_SESSION_T_ARG tiled$NL"
+TMUX_CMDS="${TMUX_CMDS}select-layout $TMUX_SESSION_T_ARG $LAYOUT$NL"
 
 # dump tmux commands
 if [ -n "$DUMP_TMUX_CMDS" ]; then

--- a/tmc
+++ b/tmc
@@ -142,18 +142,23 @@ if [ -n "$DUMP_HOSTS" -a -n "$DUMP_TMUX_CMDS" ]; then
 fi
 
 CONF="$HOME/.clusterssh/clusters"
+CONF_TAGS="$HOME/.clusterssh/tags"
 
 # check for conf file or custom cluster option
-if [ ! -f "$CONF" -a -z "$CUSTOM_CLUSTER_LINE" ]; then
-    echo "error: either config $CONF must exist or -c option must be used" 1>&2
+if [ ! -f "$CONF" -a ! -f "$CONF_TAGS" -a -z "$CUSTOM_CLUSTER_LINE" ]; then
+    echo "error: either config $CONF or $CONF_TAGS must exist or -c option must be used" 1>&2
     usage 1>&2
     exit "$ERR_ARG"
 fi
 
 CONF_LINES=""
+CONF_TAGS_LINES=""
 
 if [ -f "$CONF" ]; then
     CONF_LINES="$(grep -Ev '(^#|^$)' "$CONF")"
+fi
+if [ -f "$CONF_TAGS" ]; then
+    CONF_TAGS_LINES="$(grep -Ev '(^#|^$)' "$CONF_TAGS")"
 fi
 
 if [ -n "$CUSTOM_CLUSTER_LINE" ]; then
@@ -189,8 +194,15 @@ fi
 # check for cluster in config
 CLUSTER_LINE="$(echo "$CONF_LINES" | grep -E "^$CLUSTER ")"
 if [ -z "$CLUSTER_LINE" ]; then
-    echo "error: cluster $CLUSTER not in config $CONF" 1>&2
-    exit "$ERR_ARG"
+    CLUSTER_LINE="$(echo "$CONF_TAGS_LINES" | grep -E "^[^\s]+.*\s${CLUSTER}(\s|\$)" | sed 's/\s.*//' | tr '\n' ' ')"
+    if [ -z "$CLUSTER_LINE" ]; then
+        echo "error: cluster $CLUSTER not in config $CONF" 1>&2
+        exit "$ERR_ARG"
+    else
+        CLUSTER_LINE="$CLUSTER ${CLUSTER_LINE% }"
+        # add custom config line to configuration
+        CONF_LINES="${CONF_LINES}${NL}${CLUSTER_LINE}${NL}"
+    fi
 fi
 
 SESSION_NAME=""


### PR DESCRIPTION
`~/.clusterssh/clusters` is not the only file that is used by cssh, there is `~/.clusterssh/tags` too.