### PR TITLE
Set window name when launched within existing session with -w

### DIFF
--- a/tmc
+++ b/tmc
@@ -255,7 +255,7 @@ fi
 TMUX_SESSION_S_ARG=""
 TMUX_SESSION_T_ARG=""
 if [ "$USE_EXISTING_SESSION" = "true" ]; then
-    TMUX_CMDS="neww \"$SHELL_CMD\"$NL"
+    TMUX_CMDS="new-window -n \"cluster-$CLUSTER\" \"$SHELL_CMD\"$NL"
 else
     TMUX_SESSION_S_ARG="-s \"$SESSION_NAME\""
     TMUX_SESSION_T_ARG="-t \"$SESSION_NAME\""


### PR DESCRIPTION
$SESSION_NAME isn't available at this point so I used the same assignment it was using. 